### PR TITLE
fix(readme): update parameter names in link function of directives

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,8 +337,8 @@ A standardised approach for developing AngularJS applications in teams. This sty
     function dragUpload () {
       return {
         restrict: 'EA',
-        link: function ($scope, $element, $attrs) {
-          $element.on('dragend', function () {
+        link: function (scope, element, attrs) {
+          element.on('dragend', function () {
             // handle drop functionality
           });
         }


### PR DESCRIPTION
This PR updates the parameter names of the link function in the directive example.

The makes the naming conform with the AngularJS manual where the names with a dollar sign such as `$scope` are only used in the `controller` function.
