### PR TITLE
Added clarification to code example

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,11 @@ A standardised approach for developing AngularJS applications in teams. This sty
       .module('app', [])
       .controller()
       .factory();
+      
+    // Inside SomeController.js
+    angular
+      .module('app')
+      .controller()
     ```
 
   - Note: Using `angular.module('app', []);` sets a module, whereas `angular.module('app');` gets the module. Only set once and get for all other instances.


### PR DESCRIPTION
Added a clarifying example of the use of the `module` get/set syntax.

The footnote provided in the code can be completely missed and the example is unclear without the "get" part of the get/set syntax.