### PR TITLE
fix: get addTodo() and onSubmit() functions to expect "newTodo" property

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,13 +418,13 @@ class TodoFormController {
     // with EventEmitter wrapper
     this.onAddTodo(
       EventEmitter({
-        newTodo: this.todo
+        todo: this.todo
       });
     );
     // without EventEmitter wrapper
     this.onAddTodo({
       $event: {
-        newTodo: this.todo
+        todo: this.todo
       }
     });
   }


### PR DESCRIPTION
Let me know if I'm missing something...

Currently, `addTodo({ todo })` expects an object with a `todo` property but in the `onSubmit()` function it provides an object with the `newTodo ` property.