### PR TITLE
Fixed syntax error in TodoAutoFocus

### DIFF
--- a/README.md
+++ b/README.md
@@ -647,7 +647,7 @@ class TodoAutoFocus {
       $timeout(() => $element[0].focus());
     });
   }
-});
+}
 
 TodoAutoFocus.$inject = ['$timeout'];
 


### PR DESCRIPTION
Removed invalid closing bracket and semi colon from class definition.