### PR TITLE
Link to ng-annotate section directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -724,7 +724,7 @@ export default todo;
   * Otherwise you're stuck with `template: '<component>'` and no `bindings`
 * Consider using [Webpack](https://webpack.github.io/) for compiling your ES2015 code
 * Use [ngAnnotate](https://github.com/olov/ng-annotate) to automatically annotate `$inject` properties
-* How to use [ngAnnotate with ES6](https://www.timroes.de/2015/07/29/using-ecmascript-6-es6-with-angularjs-1-x/)
+* How to use [ngAnnotate with ES6](https://www.timroes.de/2015/07/29/using-ecmascript-6-es6-with-angularjs-1-x/#ng-annotate)
 
 **[Back to top](#table-of-contents)**
 


### PR DESCRIPTION
Since the title of the link wants to show ng-annotate with ES6, I fixed the link to link to the ng-annotate section directly.