### PR TITLE
added missing argument in autofocus directive Class

### DIFF
--- a/README.md
+++ b/README.md
@@ -647,15 +647,16 @@ Or using ES2015 `Class` (note manually calling `new TodoAutoFocus` when register
 import angular from 'angular';
 
 class TodoAutoFocus {
-  constructor() {
+  constructor($timeout) {
     this.restrict = 'A';
+    this.$timeout = $timeout;
   }
   link($scope, $element, $attrs) {
     $scope.$watch($attrs.todoAutofocus, (newValue, oldValue) => {
       if (!newValue) {
         return;
       }
-      $timeout(() => $element[0].focus());
+      this.$timeout(() => $element[0].focus());
     });
   }
 }

--- a/i18n/es.md
+++ b/i18n/es.md
@@ -619,18 +619,19 @@ O utilizando una clases ES2015 (toma en cuenta la llamada manual de `new TodoAut
 import angular from '../../angular';
 
 class TodoAutoFocus {
-  constructor() {
+  constructor($timeout) {
     this.restrict = 'A';
+    this.$timeout = $timeout;
   }
   link($scope, $element, $attrs) {
     $scope.$watch($attrs.todoAutofocus, (newValue, oldValue) => {
       if (!newValue) {
         return;
       }
-      $timeout(() => $element[0].focus());
+      this.$timeout(() => $element[0].focus());
     });
   }
-});
+}
 
 TodoAutoFocus.$inject = ['$timeout'];
 

--- a/i18n/fr-fr.md
+++ b/i18n/fr-fr.md
@@ -642,15 +642,16 @@ Ou en utilisant les `Class` d'ES2015 (notez qu'appeler manuellement `new TodoAut
 import angular from 'angular';
 
 class TodoAutoFocus {
-  constructor() {
+  constructor($timeout) {
     this.restrict = 'A';
+    this.$timeout = $timeout;
   }
   link($scope, $element, $attrs) {
     $scope.$watch($attrs.todoAutofocus, (newValue, oldValue) => {
       if (!newValue) {
         return;
       }
-      $timeout(() => $element[0].focus());
+      this.$timeout(() => $element[0].focus());
     });
   }
 }

--- a/i18n/id.md
+++ b/i18n/id.md
@@ -641,15 +641,16 @@ Atau menggunakan `Class` ES2015 (catat pemanggilan `new TodoAutoFocus` secara ma
 import angular from 'angular';
 
 class TodoAutoFocus {
-  constructor() {
+  constructor($timeout) {
     this.restrict = 'A';
+    this.$timeout = $timeout;
   }
   link($scope, $element, $attrs) {
     $scope.$watch($attrs.todoAutofocus, (newValue, oldValue) => {
       if (!newValue) {
         return;
       }
-      $timeout(() => $element[0].focus());
+      this.$timeout(() => $element[0].focus());
     });
   }
 }

--- a/i18n/pt-pt.md
+++ b/i18n/pt-pt.md
@@ -639,18 +639,19 @@ Ou utilizando ES2015 `Class` (de notar a chamada manual de `new TodoAutoFocus` a
 import angular from 'angular';
 
 class TodoAutoFocus {
-  constructor() {
+  constructor($timeout) {
     this.restrict = 'A';
+    this.$timeout = $timeout;
   }
   link($scope, $element, $attrs) {
     $scope.$watch($attrs.todoAutofocus, (newValue, oldValue) => {
       if (!newValue) {
         return;
       }
-      $timeout(() => $element[0].focus());
+      this.$timeout(() => $element[0].focus());
     });
   }
-});
+}
 
 TodoAutoFocus.$inject = ['$timeout'];
 

--- a/i18n/ru-ru.md
+++ b/i18n/ru-ru.md
@@ -641,15 +641,16 @@ export default todo;
 import angular from 'angular';
 
 class TodoAutoFocus {
-  constructor() {
+  constructor($timeout) {
     this.restrict = 'A';
+    this.$timeout = $timeout;
   }
   link($scope, $element, $attrs) {
     $scope.$watch($attrs.todoAutofocus, (newValue, oldValue) => {
       if (!newValue) {
         return;
       }
-      $timeout(() => $element[0].focus());
+      this.$timeout(() => $element[0].focus());
     });
   }
 }

--- a/i18n/zh-cn.md
+++ b/i18n/zh-cn.md
@@ -656,15 +656,16 @@ export default todo;
 import angular from 'angular';
 
 class TodoAutoFocus {
-  constructor() {
+  constructor($timeout) {
     this.restrict = 'A';
+    this.$timeout = $timeout;
   }
   link($scope, $element, $attrs) {
     $scope.$watch($attrs.todoAutofocus, (newValue, oldValue) => {
       if (!newValue) {
         return;
       }
-      $timeout(() => $element[0].focus());
+      this.$timeout(() => $element[0].focus());
     });
   }
 }


### PR DESCRIPTION
I spotted that the constructor in the Class for the autofocus directive was missing the injected $timeout. See the below image for context.

![selection_001](https://cloud.githubusercontent.com/assets/7476318/18114251/9e3da70c-6f2d-11e6-90d1-6cef3aa54a91.png)

I went ahead and made the change.