### PR TITLE
Updated missed imports to new module naming convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,8 +133,8 @@ The Common module is the container reference for all application specific compon
 
 ```js
 import angular from 'angular';
-import NavModule from './nav';
-import FooterModule from './footer';
+import NavModule from './nav/nav.module';
+import FooterModule from './footer/footer.module';
 
 const CommonModule = angular
   .module('app.common', [

--- a/i18n/es.md
+++ b/i18n/es.md
@@ -106,8 +106,8 @@ Un `Component module` es el contenedor referencia para todos los componentes reu
 
 ```js
 import angular from 'angular';
-import CalendarModule from './calendar/calendar';
-import EventsModule from './events/events';
+import CalendarModule from './calendar/calendar.module';
+import EventsModule from './events/events.module';
 
 const ComponentsModule = angular
   .module('app.components', [
@@ -588,7 +588,7 @@ Aquí hay un ejemplo utilizando una constante con una `Arrow function` y `expres
 
 ```js
 /* ----- todo/todo-autofocus.directive.js ----- */
-import angular from '../../angular';
+import angular from 'angular';
 
 const TodoAutoFocus = ($timeout) => ({
   restrict: 'A',
@@ -624,7 +624,7 @@ O utilizando una clases ES2015 (toma en cuenta la llamada manual de `new TodoAut
 
 ```js
 /* ----- todo/todo-autofocus.directive.js ----- */
-import angular from '../../angular';
+import angular from 'angular';
 
 class TodoAutoFocus {
   constructor($timeout) {

--- a/i18n/fr-fr.md
+++ b/i18n/fr-fr.md
@@ -106,8 +106,8 @@ Un module component contient les références pour tous les components réutilis
 
 ```js
 import angular from 'angular';
-import CalendarModule from './calendar';
-import EventsModule from './events';
+import CalendarModule from './calendar/calendar.module';
+import EventsModule from './events/events.module';
 
 const ComponentsModule = angular
   .module('app.components', [

--- a/i18n/id.md
+++ b/i18n/id.md
@@ -106,8 +106,8 @@ Sebuah modul Komponen adalah suatu referensi kontainer untuk semua komponen yang
 
 ```js
 import angular from 'angular';
-import CalendarModule from './calendar';
-import EventsModule from './events';
+import CalendarModule from './calendar/calendar.module';
+import EventsModule from './events/events.module';
 
 const ComponentsModule = angular
   .module('app.components', [

--- a/i18n/pt-pt.md
+++ b/i18n/pt-pt.md
@@ -105,8 +105,8 @@ Um component module é a aquele que contém referência para todos os componente
 
 ```js
 import angular from 'angular';
-import CalendarModule from './calendar';
-import EventsModule from './events';
+import CalendarModule from './calendar/calendar.module';
+import EventsModule from './events/events.module';
 
 const ComponentsModule = angular
   .module('app.components', [

--- a/i18n/ru-ru.md
+++ b/i18n/ru-ru.md
@@ -107,8 +107,8 @@ export default AppModule;
 
 ```js
 import angular from 'angular';
-import CalendarModule from './calendar';
-import EventsModule from './events';
+import CalendarModule from './calendar/calendar.module';
+import EventsModule from './events/events.module';
 
 const ComponentsModule = angular
   .module('app.components', [

--- a/i18n/zh-cn.md
+++ b/i18n/zh-cn.md
@@ -112,8 +112,8 @@ export default AppModule;
 
 ```js
 import angular from 'angular';
-import CalendarModule from './calendar';
-import EventsModule from './events';
+import CalendarModule from './calendar/calendar.module';
+import EventsModule from './events/events.module';
 
 const ComponentsModule = angular
   .module('app.components', [


### PR DESCRIPTION
I missed a few earlier, this should do it.